### PR TITLE
reorganize metadata

### DIFF
--- a/components/metadata.js
+++ b/components/metadata.js
@@ -3,18 +3,18 @@
 
 import Head from 'next/head'
 import PropTypes from 'prop-types'
-import { DEFAULT_METADATA } from 'constants/metadata'
+import { DEFAULT_METADATA } from '../constants/metadata'
 
-const Metadata = ({ title, description, image }) => {
-    const metaTitle = title
-        ? `${title} ${DEFAULT_METADATA.divider} ${DEFAULT_METADATA.suffix}`
-        : DEFAULT_METADATA.suffix
+const Metadata = ({ title, description, keywords, image }) => {
+    const metaTitle = title || DEFAULT_METADATA.title
     const metaDescription = description || DEFAULT_METADATA.description
+    const metaKeywords = keywords || DEFAULT_METADATA.keywords
     const metaImage = image || DEFAULT_METADATA.image
     return (
         <Head>
             <title>{metaTitle}</title>
             <meta name="description" content={metaDescription} />
+            <meta name="keywords" content={metaKeywords} />
             {/* Facebook */}
             <meta property="og:title" content={metaTitle} />
             <meta property="og:description" content={metaDescription} />
@@ -32,6 +32,7 @@ const Metadata = ({ title, description, image }) => {
 Metadata.propTypes = {
     title: PropTypes.string,
     description: PropTypes.string,
+    keywords: PropTypes.string,
     image: PropTypes.string,
 }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,11 +8,11 @@ import App from 'next/app'
 import NProgress from 'nprogress'
 import Router from 'next/router'
 import { ThemeProvider } from 'styled-components'
-import t from 'typy'
 import { AnimatePresence } from 'framer-motion'
 import { theme } from 'styles/theme'
 import { Metadata } from 'components/metadata'
 import * as gtag from 'utils/gtag'
+import { getMetadata } from '../utils/metadata'
 
 NProgress.configure({ showSpinner: false })
 Router.events.on('routeChangeStart', () => NProgress.start())
@@ -36,30 +36,13 @@ export default class MyApp extends App {
     render() {
         const { Component, pageProps, router } = this.props
 
-        // Get metadata information
-        let metaDescription
-        let metaTitle
-        let metaImage
-        let metaImageURL
-        if (t(pageProps, 'data.data').safeObject) {
-            const { pageData } = pageProps
-            const { data } = pageData
-            // Important: note that this is expecting properties on your Prismic page object for metadata:
-            // meta_title, meta_description, and meta_image
-            // The naming of these properties must match the above
-            // Also note the fallbacks for title, description and image
-            // Feel free to edit these to work with your naming conventions etc
-            ;({ meta_image: metaImage, meta_description: metaDescription, meta_title: metaTitle } = data)
-            metaImageURL = t(metaImage, 'url').safeObject
-            if (!metaTitle) metaTitle = data.title
-            if (!metaDescription) metaDescription = data.excerpt
-            if (!metaImageURL) metaImageURL = t(data, 'image.url').safeObject
-        }
+        // Determine Metadata
+        const { metaTitle, metaDescription, metaKeywords, metaImage } = getMetadata(pageProps)
 
         return (
             <>
                 {/* Should handle metadata for all pages w/ sensible defaults */}
-                <Metadata title={metaTitle} description={metaDescription} image={metaImageURL} />
+                <Metadata title={metaTitle} description={metaDescription} keywords={metaKeywords} image={metaImage} />
                 <ThemeProvider theme={theme}>
                     <main id="ada-content-begin">
                         <AnimatePresence exitBeforeEnter>

--- a/utils/metadata.js
+++ b/utils/metadata.js
@@ -1,0 +1,54 @@
+/*
+  All pages on the site should have default metadata, and then allow overrides in the CMS
+  Default metadata is handled in /constants/metadata.js
+*/
+
+import t from 'typy'
+import { DEFAULT_METADATA } from '../constants/metadata'
+
+const getMetadataOverrides = (data) => {
+    // Check if there are CMS overrides
+    // Metadata overrides are set via Prismic fields: meta_title, meta_description, meta_keywords, meta_image
+    // The naming of these properties must match the above
+    const { meta_title: title, meta_description: description, meta_keywords: keywords, meta_image: metaImage } = data
+    const image = t(metaImage, 'url').safeObject
+    return { title, description, keywords, image }
+}
+
+const getMetadata = (pageProps) => {
+    let metaTitle
+    let metaDescription
+    let metaKeywords
+    let metaImage
+
+    const defaults = {
+        metaTitle: DEFAULT_METADATA.suffix,
+        metaDescription: DEFAULT_METADATA.description,
+        metaKeywords: DEFAULT_METADATA.keywords,
+        metaImage: DEFAULT_METADATA.image,
+    }
+
+    if (!pageProps) {
+        return defaults
+    }
+
+    // Determine metadata based on Content Type and CMS Overrides
+    // Each page type can have it's own rules for default metadata
+    if (t(pageProps, 'pageData.data').safeObject) {
+        const { title, description, keywords, image } = getMetadataOverrides(pageProps.pageData.data)
+
+        metaTitle = title ? `${title} ${DEFAULT_METADATA.divider} ${DEFAULT_METADATA.suffix}` : defaults.metaTitle
+        metaDescription = description || defaults.metaDescription
+        metaKeywords = keywords || defaults.metaKeywords
+        metaImage = image || defaults.metaImage
+    } else {
+        metaTitle = defaults.metaTitle
+        metaDescription = defaults.metaDescription
+        metaKeywords = defaults.metaKeywords
+        metaImage = defaults.metaImage
+    }
+
+    return { metaTitle, metaDescription, metaKeywords, metaImage }
+}
+
+export { getMetadata }


### PR DESCRIPTION
@bretmorris I've applied this metadata organization to my last couple of projects and think it:
1. cleans up app.js
2. is ready to add use cases to `/utils/metadata.js` for page types that might handle metadata slightly differently (ie a blog post that uses some content field for the meta description)
3. adds in the keyword meta field, but not sure if we're moving away from including this tag